### PR TITLE
Remove the trailing whitespace from a query of carbon_stats_dashboard

### DIFF
--- a/graphite-carbon-stats/carbon_stats_dashboard.json
+++ b/graphite-carbon-stats/carbon_stats_dashboard.json
@@ -103,7 +103,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(sumSeries(carbon.agents.*.updateOperations),\"Updates\") "
+              "target": "alias(sumSeries(carbon.agents.*.updateOperations),\"Updates\")"
             },
             {
               "refId": "B",


### PR DESCRIPTION
Remove a trailing whitespace from a query of carbon_stats_dashboard to fix the `Bad Request` error.

![Screen Shot 2021-11-08 at 19 03 29](https://user-images.githubusercontent.com/87068908/140722561-04fbce21-6b37-484d-add6-bb0ccc5ba24b.png)

![Screen Shot 2021-11-08 at 19 04 45](https://user-images.githubusercontent.com/87068908/140722917-84217301-1871-4bf5-9dfd-5568302d59dc.png)